### PR TITLE
Fix: Swara symbols are misplaced while converting from unicode to ascii

### DIFF
--- a/libindic/payyans/core.py
+++ b/libindic/payyans/core.py
@@ -67,7 +67,6 @@ class Payyans():
                 letter = unicode_text[index:index + charNo]
                 if letter in self.rulesDict:
                     ascii_letter = self.rulesDict[letter]
-                    letter = letter.encode('utf-8')
                     '''
                     കിട്ടിയ അക്ഷരങ്ങളുടെ അപ്പുറത്തും ഇപ്പുറത്തും
                     സ്വരചിഹ്നങ്ങള്‍ ഫിറ്റ് ചെയ്യാനുള്ള ബദ്ധപ്പാട്


### PR DESCRIPTION
The bug.
![image](https://user-images.githubusercontent.com/1652903/218682516-15081080-da20-4d26-be86-6d9fe7969c92.png)

After bugfix
![image](https://user-images.githubusercontent.com/1652903/218683525-ea275b3e-3a57-4145-abc2-4cb49951f063.png)

Technical description:
encode() in Python3 returns byte array which can not be used to compare against string.